### PR TITLE
Prevents accidentally committing private key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 *.cfg
 nobrowser.txt
 GYB-GMail-Backup-*/
+
+# Prevents committing private key.
+privatekey.p12


### PR DESCRIPTION
Simply adds privatekey.p12 to the .gitignore.

Some of us run straight from git. ;-)
