### PR TITLE
Add configurable config folder

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -367,6 +367,7 @@ buckets = {
     "groupsmigration": QuotaBucket(10, 1, 10),
 }
 
+
 def getProgPath():
   if os.environ.get('STATICX_PROG_PATH', False):
     # StaticX static executable

--- a/gyb.py
+++ b/gyb.py
@@ -234,6 +234,10 @@ where last restore left off.')
     dest='extra_system_labels',
     nargs='+',
     help='extra labels that should be treated as system labels.')
+  parser.add_argument('--config-folder',
+    dest='config_folder',
+    help='Optional: Alternate folder to store config and credentials',
+    default=getProgPath())
   parser.add_argument('--version',
     action='store_true',
     dest='version',
@@ -363,6 +367,8 @@ buckets = {
     "groupsmigration": QuotaBucket(10, 1, 10),
 }
 
+def getConfigPath():
+  return options.config_folder
 
 def getProgPath():
   if os.environ.get('STATICX_PROG_PATH', False):
@@ -399,7 +405,7 @@ def getValidOauth2TxtCredentials(force_refresh=False):
 
 def getOauth2TxtStorageCredentials():
   auth_as = options.use_admin if options.use_admin else options.email
-  cfgFile = os.path.join(getProgPath(), '%s.cfg' % auth_as)
+  cfgFile = os.path.join(getConfigPath(), '%s.cfg' % auth_as)
   oauth_string = readFile(cfgFile, continueOnError=True, displayError=False)
   if not oauth_string:
     return
@@ -421,7 +427,7 @@ running:
 %s --action create-project --email %s
 
 """ % (sys.argv[0], options.email)
-  filename = os.path.join(getProgPath(), 'client_secrets.json')
+  filename = os.path.join(getConfigPath(), 'client_secrets.json')
   cs_data = readFile(filename, continueOnError=True, displayError=True)
   if not cs_data:
     systemErrorExit(14, MISSING_CLIENT_SECRETS_MESSAGE)
@@ -509,7 +515,7 @@ def requestOAuthAccess():
 
 def writeCredentials(creds):
   auth_as = options.use_admin if options.use_admin else options.email
-  cfgFile = os.path.join(getProgPath(), '%s.cfg' % auth_as)
+  cfgFile = os.path.join(getConfigPath(), '%s.cfg' % auth_as)
   creds_data = {
     'token': creds.token,
     'refresh_token': creds.refresh_token,
@@ -568,7 +574,7 @@ def doGYBCheckForUpdates(forceCheck=False, debug=False):
   def _LatestVersionNotAvailable():
     if forceCheck:
       systemErrorExit(4, 'GYB Latest Version information not available')
-  last_update_check_file = os.path.join(getProgPath(), 'lastcheck.txt')
+  last_update_check_file = os.path.join(getConfigPath(), 'lastcheck.txt')
   current_version = __version__
   now_time = calendar.timegm(time.gmtime())
   check_url = 'https://api.github.com/repos/jay0lee/got-your-back/releases' # includes pre-releases
@@ -641,10 +647,10 @@ def buildGAPIObject(api, httpc=None):
     httpc = google_auth_httplib2.AuthorizedHttp(credentials, _createHttpObj())
   if options.debug:
     extra_args['prettyPrint'] = True
-  if os.path.isfile(os.path.join(getProgPath(), 'extra-args.txt')):
+  if os.path.isfile(os.path.join(getConfigPath(), 'extra-args.txt')):
     config = configparser.ConfigParser()
     config.optionxform = str
-    config.read(os.path.join(getProgPath(), 'extra-args.txt'))
+    config.read(os.path.join(getConfigPath(), 'extra-args.txt'))
     extra_args.update(dict(config.items('extra-args')))
   version = getAPIVer(api)
   try:
@@ -655,7 +661,7 @@ def buildGAPIObject(api, httpc=None):
             cache_discovery=False,
             static_discovery=False)
   except googleapiclient.errors.UnknownApiNameOrVersion:
-    disc_file = os.path.join(getProgPath(), '%s-%s.json' % (api, version))
+    disc_file = os.path.join(getConfigPath(), '%s-%s.json' % (api, version))
     if os.path.isfile(disc_file):
       f = file(disc_file, 'r')
       discovery = f.read()
@@ -674,7 +680,7 @@ def buildGAPIServiceObject(api, soft_errors=False):
   credentials = getSvcAcctCredentials(scopes, auth_as)
   if options.debug:
     extra_args['prettyPrint'] = True
-  if os.path.isfile(os.path.join(getProgPath(), 'extra-args.txt')):
+  if os.path.isfile(os.path.join(getConfigPath(), 'extra-args.txt')):
     config = configparser.ConfigParser()
     config.optionxform = str
     config.read(getGamPath()+'extra-args.txt')
@@ -861,7 +867,7 @@ def _run_oauth_flow(client_id, client_secret, scopes, access_type, login_hint=No
     kwargs['login_hint'] = login_hint
   # Needs to be set so oauthlib doesn't puke when Google changes our scopes
   os.environ['OAUTHLIB_RELAX_TOKEN_SCOPE'] = 'true'
-  if not os.path.isfile(os.path.join(getProgPath(), 'oauthbrowser.txt')):
+  if not os.path.isfile(os.path.join(getConfigPath(), 'oauthbrowser.txt')):
     flow.run_console(
             authorization_prompt_message=MESSAGE_CONSOLE_AUTHORIZATION_PROMPT,
             authorization_code_message=MESSAGE_CONSOLE_AUTHORIZATION_CODE,
@@ -1012,7 +1018,7 @@ def _createClientSecretsOauth2service(projectId):
         "token_uri": "https://accounts.google.com/o/oauth2/token"
     }
 }''' % (client_id, client_secret, projectId)
-  client_secrets_file = os.path.join(getProgPath(), 'client_secrets.json')
+  client_secrets_file = os.path.join(getConfigPath(), 'client_secrets.json')
   writeFile(client_secrets_file, cs_data, continueOnError=False)
 
 PROJECTID_PATTERN = re.compile(r'^[a-z][a-z0-9-]{4,28}[a-z0-9]$')
@@ -1033,7 +1039,7 @@ def _getLoginHintProjects():
     sys.exit(3)
   login_hint = getValidateLoginHint(login_hint)
   crm, _ = getCRMService(login_hint)
-  client_secrets_file = os.path.join(getProgPath(), 'client_secrets.json')
+  client_secrets_file = os.path.join(getConfigPath(), 'client_secrets.json')
   if pfilter == 'current':
     cs_data = readFile(client_secrets_file, mode='rb', continueOnError=True, displayError=True, encoding=None)
     if not cs_data:
@@ -1080,8 +1086,8 @@ def setGAMProjectConsentScreen(httpObj, projectId, login_hint):
         pass
 
 def doCreateProject():
-  service_account_file = os.path.join(getProgPath(), 'oauth2service.json')
-  client_secrets_file = os.path.join(getProgPath(), 'client_secrets.json')
+  service_account_file = os.path.join(getConfigPath(), 'oauth2service.json')
+  client_secrets_file = os.path.join(getConfigPath(), 'client_secrets.json')
   for a_file in [service_account_file, client_secrets_file]:
     if os.path.exists(a_file):
       print('File %s already exists. Please delete or rename it before attempting to create another project.' % a_file)
@@ -1205,7 +1211,7 @@ API_SCOPE_MAPPING = {
 MESSAGE_INSTRUCTIONS_OAUTH2SERVICE_JSON = 'Please run\n\ngyb --action create-project\ngyb --action check-service-account\n\nto create and configure a service account.'
 def getSvcAcctCredentials(scopes, act_as):
   try:
-    json_string = readFile(os.path.join(getProgPath(), 'oauth2service.json'), continueOnError=True, displayError=True)
+    json_string = readFile(os.path.join(getConfigPath(), 'oauth2service.json'), continueOnError=True, displayError=True)
     if not json_string:
       print(MESSAGE_INSTRUCTIONS_OAUTH2SERVICE_JSON)
       systemErrorExit(6, None)
@@ -1222,7 +1228,7 @@ def getSvcAcctCredentials(scopes, act_as):
 
 def getSvcAccountClientId():
   try:
-    json_string = readFile(os.path.join(getProgPath(), 'oauth2service.json'), continueOnError=True, displayError=True)
+    json_string = readFile(os.path.join(getConfigPath(), 'oauth2service.json'), continueOnError=True, displayError=True)
     if not json_string:
       print(MESSAGE_INSTRUCTIONS_OAUTH2SERVICE_JSON)
       systemErrorExit(6, None)
@@ -1419,7 +1425,7 @@ def doesTokenMatchEmail():
   print("Error: you did not authorize the OAuth token in the browser with the \
 %s Google Account. Please make sure you are logged in to the correct account \
 when authorizing the token in the browser." % auth_as)
-  cfgFile = os.path.join(getProgPath(), '%s.cfg' % auth_as)
+  cfgFile = os.path.join(getConfigPath(), '%s.cfg' % auth_as)
   os.remove(cfgFile)
   return False
 
@@ -1699,6 +1705,7 @@ def main(argv):
   if options.version:
     print(getGYBVersion())
     print('Path: %s' % getProgPath())
+    print('ConfigPath: %s' % getConfigPath())
     print(ssl.OPENSSL_VERSION)
     anonhttpc = _createHttpObj()
     headers = {'User-Agent': getGYBVersion(' | ')}
@@ -2375,7 +2382,7 @@ otaBytesByService,quotaType')
       print('ERROR: --action revoke does not work with --service-account')
       sys.exit(5)
     auth_as = options.use_admin if options.use_admin else options.email
-    oauth2file = os.path.join(getProgPath(), '%s.cfg' % auth_as)
+    oauth2file = os.path.join(getConfigPath(), '%s.cfg' % auth_as)
     credentials = getOauth2TxtStorageCredentials()
     if credentials is None:
       return


### PR DESCRIPTION
Using the install folder for configuration makes it hard to containerize `gyb`. This PR adds an option to specify an alternate path to store configuration.

For example usage see [here](https://github.com/marwatk/gyb-docker).

Let me know if there are any changes I could make to improve the chances of a merge.

Thanks for GYB! It's saving me through the free ~~Apps for your Domain~~ ~~G Suite~~ Workspaces fiasco.
