### PR TITLE
fix: UnboundLocalError: local variable 'local_server' referenced befo…

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -892,7 +892,10 @@ def _wait_for_http_client(d):
     # Convert hostn to IP since apparently binding to the IP
     # reduces odds of firewall blocking us
     local_ip = _localhost_to_ip()
-    for port in range(8080, 8099):
+    local_server = None
+    tries = 0
+    for port in range(8080, 8999):
+        tries += 1
         try:
             local_server = wsgiref.simple_server.make_server(
               local_ip,
@@ -901,8 +904,10 @@ def _wait_for_http_client(d):
               handler_class=wsgiref.simple_server.WSGIRequestHandler
               )
             break
-        except OSError:
-            pass
+        except OSError as exc:
+            print("%d: %s:%d: %s" % (tries, local_ip, port, str(exc)))
+    if not local_server:
+        sys.exit("Unable to find available port")
     redirect_uri_format = (
         "http://{}:{}/" if d['trailing_slash'] else "http://{}:{}"
     )


### PR DESCRIPTION
…re assignment

In Oct. 2022 gyb worked fine on a Windows 10 system. Today I got 
```
UnboundLocalError: local variable 'local_server' referenced before assignment
```
This PR fixes the issue. Surprisingly, it took 840 ports to find one that would work:
```
...
839: 127.0.0.1:8918: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions
840: 127.0.0.1:8919: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions

Go to the following link in your browser:

        https://gyb-shortn.jaylee.us/example
```