### PR TITLE
Allow label-prefix flag to work for mbox restores

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -1637,6 +1637,9 @@ def labelsToLabelIds(labels):
         allLabels[a_label['name']] = a_label['id']
   labelIds = list()
   for label in labels:
+    labelparts = label.split("/")
+    labelparts = [x.upper() if x.lower() in reserved_labels else x for x in labelparts]
+    label = "/".join(labelparts)
     # convert language system labels to standard
     label = labellang.mappings.get(label.upper(), label)
     if label.upper() in system_labels:
@@ -2483,6 +2486,9 @@ def main(argv):
               cased_labels.append(label)
             else:
               cased_labels.append(label)
+          if options.label_prefix:
+            prefix = "/".join(options.label_prefix)
+            cased_labels = ["%s/%s" % (prefix, label) for label in cased_labels]
           labelIds = labelsToLabelIds(cased_labels)
           rewrite_line(" message %s - %s%%" % (current, mbox_pct))
           full_message = message.as_bytes()


### PR DESCRIPTION
Addresses issue #216 which, although closed, is still not working.

Line 1641 normalizes the path so that reserved labels are capitalized. For instance, `Prefix/Inbox/Favorites` would become `Prefix/INBOX/Favorites`. This prevented the `WARNING: failed to create (existing?) label` messages I got when importing my mbox file from Google Takeout with a prefix.