### PR TITLE
Add setup.py to allow pip install

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -2804,7 +2804,7 @@ otaBytesByService,quotaType')
     for label in labels:
       createLabel(label)
 
-if __name__ == '__main__':
+def command_line():
   if sys.version_info[0] < 3 or sys.version_info[1] < 7:
     print('ERROR: GYB requires Python 3.7 or greater.')
     sys.exit(3)
@@ -2834,3 +2834,16 @@ if __name__ == '__main__':
     except NameError:
       pass
     sys.exit(4)
+
+def _installed_main():
+  """
+  If gyb was installed with pip or setup.py, set the default --config-folder
+  paramter to be the directory this script was called from instead of where
+  the script actually is.
+  """
+  if "--config-folder" not in sys.argv:
+    sys.argv.extend(["--config-folder", "."])
+  command_line()
+
+if __name__ == '__main__':
+  command_line()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+# from gyb import __author__, __email__, __program_name__, __version__
+
+__author__ = "Jay Lee"
+__email__ = 'jay0lee@gmail.com'
+__program_name__ = 'Got Your Back: Gmail Backup'
+__version__ = '1.80'
+
+
+with open("README.md", "r") as _:
+    readme = _.read()
+
+setup(
+    name="gyb",
+    version=__version__,
+    packages=["."],
+    zip_safe=True,
+    url="https://github.com/GAM-team/got-your-back",
+    license="Apache 2.0",
+    author=__author__,
+    author_email=__email__,
+    description=__program_name__,
+    long_description=readme,
+    long_description_content_type="text/markdown",
+    python_requires=">=3.7",
+    install_requires=[
+        "httplib2>=0.17.0",
+        "google-api-python-client>=2.0",
+        "google-auth>=1.11.2",
+        "google-auth-httplib2",
+        "google-auth-oauthlib>=0.4.1",
+    ],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Communications :: Email",
+        "Topic :: Utilities",
+    ],
+    entry_points={
+        "console_scripts": [
+            "gyb=gyb:_installed_main"
+        ],
+    }
+)


### PR DESCRIPTION
Clone this repository and use `python setup.py install` . After install, `gyb` can be used on the command line anywhere (`client_secrets.json` and `oauth2service.json` need to be in the current directory or use `--config-folder`).

For installation, you could also use `pip install git+https://github.com/GAM-team/got-your-back.git` if this PR is accepted. (`pip install got-your-back` might be possible if Mr. Lee wishes to use [twine](https://twine.readthedocs.io/en/stable/) to upload the package to [PyPI](https://pypi.org/)).

While I would have liked to import from `gyb.py` on [line 4 of setup.py](https://github.com/GAM-team/got-your-back/compare/main...phistrom:got-your-back:add-setup-py?expand=1#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R56), the packages in that module may not have been installed yet, leading to an import error. In an effort to modify as little of the original code as possible, I copied the values of the `__author__`, `__email__`, `__program_name__`, and `__version__` to get around this.

[Line 56 of setup.py](https://github.com/GAM-team/got-your-back/compare/main...phistrom:got-your-back:add-setup-py?expand=1#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R56) adds `gyb` to the PATH. Tested on Windows (Python 3.12), MacOS (Python 3.11), and the `python:3.12-slim` Docker container (Debian Linux).

The original `gyb.py` script was modified as minimally as possible to allow `setup.py` to make an entry point script. The behavior should be precisely the same whether or not it was installed with pip.