### PR TITLE
Prevent GYB restore process from stopping on Input/output errors with .eml files

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -2364,8 +2364,6 @@ def main(argv):
       current += 1
       message_filename = x[2]
       message_num = x[0]
-      print(message_num)
-      print(message_filename)
       if not os.path.isfile(os.path.join(options.local_folder,
         message_filename)):
         print('WARNING! file %s does not exist for message %s'


### PR DESCRIPTION
When reading .eml files during restore, some files may be corrupted causing `OSError: [Errno 5] Input/output error`. Previously, GYB would stop the entire restore process on encountering this error. 

This commit adds error handling to catch such OS errors and log a warning instead of aborting, allowing the restore operation to continue with other files.